### PR TITLE
Correct typo for GC content filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 PRINSEQ++ is a C++ implementation of the prinseq-lite.pl program. It can be used to filter, reformat or trim genomic and metagenomic sequence data. It is 5X faster than prinseq-lite.pl and uses less RAM thanks to the use of multi-threading and the cboost libraries. It can read and write compressed (gzip) files, drastically reducing the use of hard drive.
 
 ## Install from Conda
+
 You can install from [Conda](https://anaconda.org/bioconda/prinseq-plus-plus) either in its own channel:
+
 ```
 conda create -n prinseq-plus-plus -c conda-forge -c bioconda prinseq-plus-plus
 conda activate prinseq-plus-plus
@@ -18,101 +20,99 @@ conda install -c conda-forge -c bioconda prinseq-plus-plus
 
 See [below](#install-from-source) to install prinseq++ from source if you don't want to use conda.
 
-
-
 ## Usage
 
     -h | -help
         Print the help page; ignore other arguments.
-        
+
     -v | -version
         Print version; ignore other arguments.
-        
-    -threads 
+
+    -threads
         Nuber of threads to use. Note that if more than one thread is used, output
         sequences might not be in the same order as input sequences. (Default=1)
-        
+
     -VERBOSE <int>
         Format of the report of filtered reads, VERBOSE=1 prints information only
-        on the filters that removed sequences. VERBOSE=2 prints numbers for filters 
-        in order (min_len, max_len, min_cg, max_cg, min_qual_score, min_qual_mean,
-        ns_max_n, noiupac, derep, lc_entropy, lc_dust, trim_tail_left, trim_tail_right, 
+        on the filters that removed sequences. VERBOSE=2 prints numbers for filters
+        in order (min_len, max_len, min_gc, max_gc, min_qual_score, min_qual_mean,
+        ns_max_n, noiupac, derep, lc_entropy, lc_dust, trim_tail_left, trim_tail_right,
         trim_qual_left, trim_qual_right, trim_left, trim_right) to compare stats of diferent files.
         VERBOSE=0 prints nothing.
-        (Default=1)    
-    
+        (Default=1)
+
     ***** INPUT OPTIONS *****
-    
+
     -fastq <file>
         Input file in FASTQ format. Can also read a compressed (.gz) file.
-        
+
     -fastq2 <file>
-        Input file in FASTQ format for pair-end reads. Can also read a 
+        Input file in FASTQ format for pair-end reads. Can also read a
         compressed (.gz) file.
-        
-    -FASTA 
-        Input is in fasta format (no quality). Note that the output format is 
+
+    -FASTA
+        Input is in fasta format (no quality). Note that the output format is
         still fastq by default. Quality will be treated as 31 (A) for all bases.
-        
+
     -phred64
         Input quality is in phred64 format. This is for older Illumina/Solexa reads.
-        
+
     ***** OUTPUT OPTION *****
-    
+
     -out_format <int>
         Set output format. 0 FASTQ, 1 FASTA. (Default=0)
-        
+
     -out_name <string>
         For pair-end sequences, the output files are <string>_good_out_R1 and
         <string>_good_out_R2 for pairs where both reads pass quality control,
         <string>_single_out_R1 and <string>_single_out_R2 for read that passed
-        quality control but mate did not. <string>_bad_out_R1 and <string>_bad_out_R2  
-        for reads that fail quality controls. [Default = random size 6 string] 
-    
+        quality control but mate did not. <string>_bad_out_R1 and <string>_bad_out_R2
+        for reads that fail quality controls. [Default = random size 6 string]
+
     -rm_header
         Remove the header in the 3rd line of the fastq (+header -> +). This does
         not change the header in the 1st line (@header).
-        
-    -out_gz 
+
+    -out_gz
         Write the output to a compressed file (WARNING this can be really SLOW,
         will be fixed in a future release)
-        
+
     -out_good  , -out_single , -out_bad,
     -out_good2 , -out_single2, -out_bad2
         Rename the output files idividually, this overwrites the names given by
-        -out_name only for the selected files. File extension won't be added 
+        -out_name only for the selected files. File extension won't be added
         automatically. (TIP: if you don't need a file, set its name to /dev/null)
-        
+
     ***** FILTER OPTIONS ******
-        
+
     -min_len <int>
         Filter sequence shorter than min_len.
-    
+
     -max_len <int>
         Filter sequence longer than max_len.
-        
+
     -min_gc <float>
         Filter sequence with GC percent content below min_gc.
-    
+
     -max_gc <float>
         Filter sequence with GC percent content above min_gc.
-    
+
     -min_qual_score <int>
-        Filter sequence with at least one base with quality score below 
+        Filter sequence with at least one base with quality score below
         min_qual_score.
-        
+
     -min_qual_mean <int>
         Filter sequence with quality score mean below min_qual_mean.
-        
+
     -ns_max_n <int>
         Filter sequence with more than ns_max_n Ns.
-   
-    -noiupac         
+
+    -noiupac
         Filter sequence with characters other than A, C, G, T or N.
 
     -derep
         Filter duplicated sequences. This only remove exact duplicates.
-        
+
     -lc_entropy=[float]
         Filter sequences with entropy lower than [float]. [float] should be in
         the 0-1 interval. (Default=0.5)
@@ -120,15 +120,15 @@ See [below](#install-from-source) to install prinseq++ from source if you don't 
     -lc_dust=[float]
         Filter sequences with dust_score lower than [float]. [float] should be in
         the 0-1 interval. (Default=0.5)
-        
+
     ***** TRIM OPTIONS *****
-    
+
     -trim_left <integer>
         Trim <integer> bases from the left (5'->3').
-        
+
     -trim_right <integer>
         Trim <integer> bases from the right (3'->5').
-    
+
     -trim_tail_left <integer>
         Trim poly-A/T tail with a minimum length of <integer> at the
         5'-end.
@@ -144,20 +144,20 @@ See [below](#install-from-source) to install prinseq++ from source if you don't 
 
     -trim_qual_left=[float]
         Trim recursively from the 3'-end chunks of length -trim_qual_step if the
-        mean quality of the first -trim_qual_window bases is less than [float]. 
+        mean quality of the first -trim_qual_window bases is less than [float].
         (Default=20)
-        
+
     -trim_qual_right=[float]
         Trim recursively from the 5'-end chunks of length -trim_qual_step if the
-        mean quality of the last -trim_qual_window bases is less than [float]. 
-        (Default=20)    
+        mean quality of the last -trim_qual_window bases is less than [float].
+        (Default=20)
 
     -trim_qual_window [int]
         Size of the window used by trim_qual_left and trim_qual_right (Default=5)
 
     -trim_qual_step [int]
         Step size used by trim_qual_left and trim_qual_right (Default=2)
-    
+
     -trim_qual_type <string>
         Type of quality score calculation to use. Allowed options are min,
         mean, max and sum. [default= min]
@@ -166,19 +166,21 @@ See [below](#install-from-source) to install prinseq++ from source if you don't 
 
 If you don't want to use conda, there are several other ways that you can install `prinseq++`. Try one of these and post an issue if you get stuck.
 
-
 ### General requirements to install from source
+
 1. g++
 2. make
-3. boost-devel ( "sudo apt-get install libboost-all-dev" in Ubuntu) 
+3. boost-devel ( "sudo apt-get install libboost-all-dev" in Ubuntu)
 4. pthread
 
 ### Download
+
 If you are just interested in compiling and using PRINSEQ++, download the latest [version](https://github.com/Adrian-Cantu/PRINSEQ-plus-plus/releases/download/v1.2.4/prinseq-plus-plus-1.2.4.tar.gz).
-You can also download the [binary](https://github.com/Adrian-Cantu/PRINSEQ-plus-plus/releases/download/v1.2.4/binary_prinseq-plus-plus-1.2.4.tar.gz). 
+You can also download the [binary](https://github.com/Adrian-Cantu/PRINSEQ-plus-plus/releases/download/v1.2.4/binary_prinseq-plus-plus-1.2.4.tar.gz).
 If you want to edit the source code, clone this repository.
 
 ### To install
+
 ```bash
 tar -xvf prinseq-plus-plus-1.2.4.tar.gz
 cd prinseq-plus-plus-1.2.4
@@ -189,17 +191,19 @@ sudo make install
 ```
 
 ### To install `prinseq++` from this Git repository
+
 ```bash
 git clone https://github.com/Adrian-Cantu/PRINSEQ-plus-plus.git
 cd PRINSEQ-plus-plus
 ./autogen.sh
 ./configure
 make
-make test 
+make test
 sudo make install
 ```
 
 ### To check instalation
+
 ```
 prinseq++ -h
 ```
@@ -207,5 +211,3 @@ prinseq++ -h
 ## Contributors
 
 `Prinseq++` was written by Adrian Cantu, with contributions from Jeff Sadural and Katelyn McNair. Rob Edwards helped here and there.
-
-

--- a/README.md.in
+++ b/README.md.in
@@ -35,7 +35,7 @@ See [below](#install-from-source) to install prinseq++ from source if you don't 
     -VERBOSE <int>
         Format of the report of filtered reads, VERBOSE=1 prints information only
         on the filters that removed sequences. VERBOSE=2 prints numbers for filters 
-        in order (min_len, max_len, min_cg, max_cg, min_qual_score, min_qual_mean,
+        in order (min_len, max_len, min_gc, max_gc, min_qual_score, min_qual_mean,
         ns_max_n, noiupac, derep, lc_entropy, lc_dust, trim_tail_left, trim_tail_right, 
         trim_qual_left, trim_qual_right, trim_left, trim_right) to compare stats of diferent files.
         VERBOSE=0 prints nothing.

--- a/changelog
+++ b/changelog
@@ -1,3 +1,5 @@
+1.2.5
+- Correct typo in log file GC filter stats reporting
 1.2.3
 - Clarify error message for missing boost libraries.
 1.2.2
@@ -10,12 +12,12 @@ the std placeholders.
 - Added -trim_left, -trim_right to trim reads unconditionally
 - Added the -phred64 option for old files
 - Added -out_good  , -out_single , -out_bad, -out_good2 , -out_single2, -out_bad2
-    in case you want to manually name output files. unused options default to the default
-    filename. You can even send two output streams to the same file.
+in case you want to manually name output files. unused options default to the default
+filename. You can even send two output streams to the same file.
 - fixed a bug were -noiupac was filtering RNA sequences. (those containing 'U')
-    
+
 1.1
-Added verbose options and an options to read fasta files. Speed up run time 
+Added verbose options and an options to read fasta files. Speed up run time
 by only performing filters on good reads.
 1.0.1
 Fixed a race condition where pair_read::read_read could pull reads from the R1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -592,8 +592,8 @@ void* do_single (void * arguments) {
         if (noiupac) {(*(verbose_vec->noiupac))[id] += read->noiupac();}
         if (min_len) {(*(verbose_vec->min_len))[id] += read->min_len(min_len);}
         if (max_len) {(*(verbose_vec->max_len))[id] += read->max_len(max_len);}
-        if (max_gc < 100) {(*(verbose_vec->max_cg))[id] += read->max_gc(max_gc);}
-        if (min_gc > 0) {(*(verbose_vec->min_cg))[id] += read->min_gc(min_gc);}
+        if (max_gc < 100) {(*(verbose_vec->max_gc))[id] += read->max_gc(max_gc);}
+        if (min_gc > 0) {(*(verbose_vec->min_gc))[id] += read->min_gc(min_gc);}
         if (derep) {
             pthread_mutex_lock(& read_mutex4);
             derep_1=filter->contains(read->seq_seq);
@@ -633,8 +633,8 @@ void* do_pair (void * arguments) {
             if (noiupac) {(*(verbose_vec->noiupac))[id] += read->noiupac();}
             if (min_len) {(*(verbose_vec->min_len))[id] += read->min_len(min_len);}
             if (max_len) {(*(verbose_vec->max_len))[id] += read->max_len(max_len);}
-            if (max_gc < 100) {(*(verbose_vec->max_cg))[id] += read->max_gc(max_gc);}
-            if (min_gc > 0) {(*(verbose_vec->min_cg))[id] += read->min_gc(min_gc);}
+            if (max_gc < 100) {(*(verbose_vec->max_gc))[id] += read->max_gc(max_gc);}
+            if (min_gc > 0) {(*(verbose_vec->min_gc))[id] += read->min_gc(min_gc);}
             if (derep) {
                 pthread_mutex_lock(& read_mutex4);
                 derep_1=filter->contains(read->read1->seq_seq);
@@ -682,7 +682,7 @@ Option:
     -VERBOSE <int>
         Format of the report of filtered reads, VERBOSE=1 prints information only
         on the filters that removed sequences. VERBOSE=2 prints numbers for filters 
-        in order (min_len, max_len, min_cg, max_cg, min_qual_score, min_qual_mean,
+        in order (min_len, max_len, min_gc, max_gc, min_qual_score, min_qual_mean,
         ns_max_n, noiupac, derep, lc_entropy, lc_dust, trim_tail_left, trim_tail_right, 
         trim_qual_left, trim_qual_right, trim_left, trim_right) to compare stats of diferent files.
         VERBOSE=0 prints nothing.

--- a/src/verbose.cpp
+++ b/src/verbose.cpp
@@ -19,8 +19,8 @@
 verbose::verbose(int k, int verb) : threads(k), verbosity(verb)  {
     min_len=new std::vector<int>(threads,0);
     max_len=new std::vector<int>(threads,0);
-    min_cg=new std::vector<int>(threads,0);
-    max_cg=new std::vector<int>(threads,0);
+    min_gc=new std::vector<int>(threads,0);
+    max_gc=new std::vector<int>(threads,0);
     min_qual_score = new std::vector<int>(threads,0);
     min_qual_mean= new std::vector<int>(threads,0);
     ns_max_n= new std::vector<int>(threads,0);
@@ -39,8 +39,8 @@ verbose::verbose(int k, int verb) : threads(k), verbosity(verb)  {
 void verbose::accumulate(void) {
     total_min_len=std::accumulate((*min_len).begin(), (*min_len).end(), 0);
     total_max_len=std::accumulate((*max_len).begin(), (*max_len).end(), 0);
-    total_min_cg=std::accumulate((*min_cg).begin(), (*min_cg).end(), 0);
-    total_max_cg=std::accumulate((*max_cg).begin(), (*max_cg).end(), 0);
+    total_min_gc=std::accumulate((*min_gc).begin(), (*min_gc).end(), 0);
+    total_max_gc=std::accumulate((*max_gc).begin(), (*max_gc).end(), 0);
     total_min_qual_score=std::accumulate((*min_qual_score).begin(), (*min_qual_score).end(), 0);
     total_min_qual_mean=std::accumulate((*min_qual_mean).begin(),(*min_qual_mean).end(),0);
     total_ns_max_n=std::accumulate((*ns_max_n).begin(), (*ns_max_n).end(), 0);
@@ -61,8 +61,8 @@ void verbose::print(void){
     if (verbosity == 1 ) {
         if (total_min_len) { std::cout << total_min_len <<" reads removed by -min_len" << std::endl;}
         if (total_max_len) { std::cout << total_max_len <<" reads removed by -max_len" << std::endl;}
-        if (total_min_cg) { std::cout << total_min_cg <<" reads removed by -min_cg" << std::endl;}
-        if (total_max_cg) { std::cout << total_max_cg <<" reads removed by -max_cg" << std::endl;}
+        if (total_min_gc) { std::cout << total_min_gc <<" reads removed by -min_gc" << std::endl;}
+        if (total_max_gc) { std::cout << total_max_gc <<" reads removed by -max_gc" << std::endl;}
         if (total_min_qual_score) { std::cout << total_min_qual_score <<" reads removed by -min_qual_score" << std::endl;}
         if (total_min_qual_mean) { std::cout << total_min_qual_mean <<" reads removed by -min_qual_mean" << std::endl;}
         if (total_ns_max_n) { std::cout << total_ns_max_n <<" reads removed by -ns_max_n" << std::endl;}
@@ -79,8 +79,8 @@ void verbose::print(void){
     } else if (verbosity==2) {
         std::cout << total_min_len        << std::endl;
         std::cout << total_max_len        << std::endl;
-        std::cout << total_min_cg         << std::endl;
-        std::cout << total_max_cg         << std::endl;
+        std::cout << total_min_gc         << std::endl;
+        std::cout << total_max_gc         << std::endl;
         std::cout << total_min_qual_score << std::endl;
         std::cout << total_min_qual_mean  << std::endl;
         std::cout << total_ns_max_n       << std::endl;

--- a/src/verbose.h
+++ b/src/verbose.h
@@ -30,8 +30,8 @@ class verbose {
     
     int total_min_len;
     int total_max_len;
-    int total_min_cg;
-    int total_max_cg;
+    int total_min_gc;
+    int total_max_gc;
     int total_min_qual_score;
     int total_min_qual_mean;
     int total_ns_max_n;
@@ -48,8 +48,8 @@ class verbose {
     
     std::vector<int>* min_len;
     std::vector<int>* max_len;
-    std::vector<int>* min_cg;
-    std::vector<int>* max_cg;
+    std::vector<int>* min_gc;
+    std::vector<int>* max_gc;
     std::vector<int>* min_qual_score;
     std::vector<int>* min_qual_mean;
     std::vector<int>* ns_max_n;


### PR DESCRIPTION
I noticed when making a [MultiQC](https://github.com/ewels/MultiQC) module for PRINSEQ++ that there was a typo in the STDOUT where the VERBOSE=1 output reported e.g. `-min_cg` rather than `-min_gc`. This PR corrects this in all places (note this iwas via a brute 'search/replace', however a skim of changes naïvely look OK  to me )